### PR TITLE
French translation

### DIFF
--- a/nutshell.js
+++ b/nutshell.js
@@ -253,6 +253,34 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
             // What punctuation (in this language) signifies the END of a sentence? Note, this is a regex.
             endPunctuation: /[.?!]\s/g
         },
+        fr: {
+
+            // Button text
+            closeAllNutshells: `fermer toutes les Nutshells`,
+
+            // Nutshell errors...
+            notFoundError: `Oh oh, la page n'as pas été trouvée! Lien à vérifier:`,
+            wikiError: `Oh oh, Wikipédia n'envoie rien, ou le lien est cassé. S'il vous plaît, vérifiez:`,
+            corsError: `Oh oh, la page a été trouvée mais refuse de nous donner son contenu! Vérifiez que l'autre site a Nutshell d'installé ou CORS d'activé:`,
+            sectionIDError: `Oh oh, il n'existe pas de section avec l'identifiant #[ID]! Ça pourrait venir d'une faute de frappe ou d'une orthographe d'origine différente.`,
+            startTextError: `Oh oh, il n'existe pas de paragraphe contenant “[start]”! Ça pourrait venir d'une faute de frappe.`,
+
+            // Embed modal!
+            embedStep0: `Vous pouvez insérer ceci comme "explication expansible" dans votre propre blog/site!
+                        Cliquez pour prévisualiser → [EXAMPLE]`,
+            embedStep1: `Étape 1) Copiez ce code dans le [HEAD] de votre site: [CODE]`,
+            embedStep2: `Étape 2) Dans votre article, créez un lien vers [LINK]
+                         et assurez vous que le texte du lien démarre avec :deux-points,
+                         <a href="#">:comme ça</a>,
+                         pour que Nutshell sache que c'est expansible.`,
+            embedStep3: `Step 3) Et voila! 🎉`,
+
+            // What punctuation (in this language) should we KEEP after an expandable opens?
+            keepPunctuation: `.,?!)_~'"’”`,
+            // What punctuation (in this language) signifies the END of a sentence? Note, this is a regex.
+            endPunctuation: /[.?!]\s/g
+
+        },
         nl: {
 
             // Button text


### PR DESCRIPTION
Salut,
Thank you for sharing Nutshell.js!

Because translation is hard to review for a maintainer here is the comprehensive list of the choices I made :
- In `closeAllNutshells` I capitalized “nutshell” instead of translating it to be consistent with the name of the project and the rest of the explanations, and also because “coquille de noix” is a bit of a mouthful.
- I put the fr strings in between the Esperanto and Dutch to keep the alphabetical order as far as it exists (up to the German strings).
- In `sectionIDError` the “watch out for typos”  as been replaced by something equivalent to “it could be a typo”
    - Imperative mood with “watching out” could sound like berating if translated 1:1 (in general , the imperative mood is risky with the french, we do have authority issues 😄)
- Same with `startTextError`.
- “that’s all, folks!” has been replaced by “et voila!” because “<something>, folks!” can’t be translated 1:1, unless you want to sound like a high schooler in the 2010s. (At that time, we unironically francised words like “cool” into “frais”, and “folks” as “les gens” which we used like you’d use “guys” although it sounds as casual as “peeps” if not a bit more … this should have been in a Nutshell right?)
    - If that decision is not acceptable you can go with “Et c’est tout les gens! 🎉” as a 1:1-ish version.

the rest is as 1:1 as it can without sounding unnatural (at least to me).