### PR TITLE
Hide headings in embedded page

### DIFF
--- a/nutshell.js
+++ b/nutshell.js
@@ -1112,6 +1112,10 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
 
                     // IF NO SECTION ID, give entire article
                     if(!queryString || queryString.trim()==''){
+                        // Hidden sections should still be hidden
+                        Nutshell.hideHeadings(safeEl);
+                        // Folded sections need to convert relative links to absolute
+                        _convertRelativeToAbsoluteLinks("a", "href", url, safeEl);
                         // Article is assumed to be the container of the first <p>
                         let assumedArticle = safeEl.querySelector('p').parentNode;
                         resolve(assumedArticle);

--- a/test/test.html
+++ b/test/test.html
@@ -7,11 +7,11 @@
 </head>
 <body>
 
-<h2>Heading</h2>
+<h2>Heading File 1</h2>
 
 <p>
     And some random crap below.
-    <a href="#heading">:recursion, yo</a>.
+    <a href="test2.html">:mutual recursion, yo</a>.
 </p>
 
 </body>

--- a/test/test2.html
+++ b/test/test2.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>test cases</title>
+    <script src="../nutshell.js"></script>
+</head>
+<body>
+
+<h2>Heading File 2</h2>
+
+<p>
+    And some random crap below.
+    <a href="test.html">:mutual recursion, yo</a>.
+
+    <a href="#invis">:a call from beyond</a>.
+</p>
+
+<h2>:Folded Heading</h2>
+
+<p>
+    This should be folded.
+</p>
+
+<h2>:x Invisible Heading</h2>
+
+<p>
+    This shouldn't be visible until expanded.
+</p>
+
+</body>
+</html>


### PR DESCRIPTION
When embedding another full page that uses Nutshell, I'd expect [hidden headings](https://github.com/ncase/nutshell#hiding-headings) to remain hidden or invisible.
This should handle both `:` and `:x` cases
