### PR TITLE
Added workaround support for wikipedia specific sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,9 @@
         <li>
             <a href="#WhoMadeThis">:Who made this?</a>
         </li>
+        <li>
+            <a href="https://en.wikipedia.org/wiki/Binary_number#Addition">:Binary Addition</a>
+        </li>
     </ul>
 
     <!-- Pointy McPointFace -->

--- a/nutshell.js
+++ b/nutshell.js
@@ -884,7 +884,17 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
 
                             // create valid links 
                             pageHTML = pageHTML.replaceAll(/href="\/wiki/g, `href="https://${domain}.wikipedia.org/wiki`);
-                            // Cache it
+                            
+                            // get all a tags with wiki links and any title and change inner text to have : in front 
+                            // don't touch images
+                            pageHTML = pageHTML.replace(/<a.*?href="https:\/\/.*?\.wikipedia\.org\/wiki\/(.*?)".*?>(.*?)<\/a>/g, (match, p1, p2) => {
+                                // if it's an image, don't touch it
+                                if(p1.includes("File:")){
+                                    return match;
+                                }
+                                return `<a href="https://${domain}.wikipedia.org/wiki/${p1}">:${p2}</a>`;
+                            });
+
                             Nutshell.htmlCache[url] = pageHTML;
                             // FULFIL THE PROPHECY
                             resolvePurifiedHTML( Nutshell.htmlCache[url] );

--- a/nutshell.js
+++ b/nutshell.js
@@ -813,7 +813,7 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
     Nutshell.promisePurifiedHTMLFromURL = (url)=>{
 
         // A promise...
-        return new Promise((resolvePurifiedHTML, rejectPurifiedHTML)=>{
+        return new Promise(async (resolvePurifiedHTML, rejectPurifiedHTML)=>{
 
             // If already in cache, return that.
             if(Nutshell.htmlCache[url]){
@@ -831,17 +831,62 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
                     articleTitle = decodeURIComponent( splitPath[splitPath.length-1] );
                 // Which language wikipedia? (including Simple...)
                 let domain = urlObject.host.split('.')[0];
-
+                // get section of article, if any
+                let sectionID = urlObject.hash.slice(1);
+                
                 // Fetch lede
                 let resourceParams = {
                     // Request from anywhere, in JSON
                     action: "query", origin: "*", format: "json",
                     // Extract just the lead paragraph & thumbnail
-                    prop: "extracts|pageimages", exintro: "", pithumbsize:500,
+                    prop: "extracts|pageimages|sections", exintro: "", pithumbsize:500,
                     // THIS PAGE
                     titles: articleTitle
                 }
+                // Parse API
+                let params = {
+                    action: "parse", origin: "*", format: "json",
+                    page: articleTitle,
+                    prop: "text|sections"
+                }
                 let resourceQueryString = _objectToURLParams(resourceParams);
+                
+                let parseQueryString = _objectToURLParams(params);
+
+                let parseURL = `https://${domain}.wikipedia.org/w/api.php?${parseQueryString}`
+                let found = false;
+                await fetch(parseURL)
+                    .then(response => response.json())
+                    .then(data => {
+                        const sections = data.parse.sections;
+                        for(let i = 0; i < sections.length; i++){
+                            if(sections[i].anchor === sectionID){
+                                params.section = sections[i].index;
+                                found = true;
+                                break;
+                            }
+                        } 
+                    }
+                );
+
+                if(found){
+                    fetch(`https://${domain}.wikipedia.org/w/api.php?${_objectToURLParams(params)}`)
+                        .then(response => response.json())
+                        .then(data => {
+                            let pageHTML = data.parse.text['*'];
+                            // show images
+                            pageHTML = pageHTML.replaceAll("\"//upload.wikimedia.org/", "\"https://upload.wikimedia.org/");
+                            // remove all elements with class editsection
+                            pageHTML = pageHTML.replace(/<span class="mw-editsection">.*?<\/span>/g, "");
+                            // remove all links with title that starts with Edit Section
+                            pageHTML = pageHTML.replace(/<a.*?title="Edit section.*?<\/a>/g, "");
+                            pageHTML = pageHTML.replace(/<span class="mw-editsection-bracket">.*?<\/span>/g, "");
+                            Nutshell.htmlCache[url] = pageHTML;
+                            // FULFIL THE PROPHECY
+                            resolvePurifiedHTML( Nutshell.htmlCache[url] );
+
+                        });
+                }else{
                 let resourceURL = `https://${domain}.wikipedia.org/w/api.php?${resourceQueryString}`;
                 fetch(resourceURL)
                     .then(response => response.json())
@@ -863,7 +908,7 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
                         resolvePurifiedHTML(pageHTML);
 
                     });
-
+                }
                 // (Wait some time before giving up, and telling user)
                 setTimeout(()=>{
                     rejectPurifiedHTML(
@@ -1074,7 +1119,7 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
             // Get expandable's url & queryString
             let href = expandable.href,
                 splitHref = href.split("#"),
-                url = splitHref[0],
+                url = expandable.href,
                 queryString = splitHref[1];
 
             // The container for the Section... get it, boiiiiii.

--- a/nutshell.js
+++ b/nutshell.js
@@ -881,6 +881,10 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
                             // remove all links with title that starts with Edit Section
                             pageHTML = pageHTML.replace(/<a.*?title="Edit section.*?<\/a>/g, "");
                             pageHTML = pageHTML.replace(/<span class="mw-editsection-bracket">.*?<\/span>/g, "");
+
+                            // create valid links 
+                            pageHTML = pageHTML.replaceAll(/href="\/wiki/g, `href="https://${domain}.wikipedia.org/wiki`);
+                            // Cache it
                             Nutshell.htmlCache[url] = pageHTML;
                             // FULFIL THE PROPHECY
                             resolvePurifiedHTML( Nutshell.htmlCache[url] );


### PR DESCRIPTION
Like this: 

![image](https://github.com/user-attachments/assets/4fb88039-94c4-4950-831f-e62e29c21cbb)

What I did? 
 - Added a request to wikipedia parse API to parse sections of the given page, and look at the section ID given in the URL by developer.
 - If section ID is found, then make another request to parse html/text for that certain section.
 