### PR TITLE
Only purify HTML for cross-origin nutshells

### DIFF
--- a/nutshell.js
+++ b/nutshell.js
@@ -1076,9 +1076,10 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
 
     // PURIFY. (& make src's absolute)
     let _purifyHTML = (rawHTML, baseURL)=>{
-
+        let is_same_origin = new URL(baseURL).origin == window.location.origin;
+        
         // DOMPurify: no styles, no scripts, iframes allowed (but sandboxed later)
-        let cleanHTML = DOMPurify.sanitize(rawHTML,{
+        let cleanHTML = is_same_origin ? rawHTML : DOMPurify.sanitize(rawHTML,{
             FORBID_ATTR: ['style','id','class'],
             FORBID_TAGS: ['style'],
             ADD_TAGS: ['iframe','audio','video']


### PR DESCRIPTION
I wanted to use nutshell on my website with latex (well [katex](https://katex.org/) actually) but all the `class="katex-mathml"` attributes were being stripped so the latex wouldn't display properly.

This PR changes the code such that the HTML is only cleaned when coming from a different origin. The argument is that users know their own website well enough and will often want styling to carry across pages.

Despite being only 2 lines of code this is a big change. I don't know enough about the library (or javascript honestly) to know if this change is desirable. This will likely break things for some users where an `id` or `class` within a nutshell now conflicts with the parent page and results in weird formatting. However, I thought I'd submit a PR in case this is useful for others as it was for me.