### PR TITLE
Fix: Properly hide source when nutshell is from the same page

### DIFF
--- a/nutshell.js
+++ b/nutshell.js
@@ -1419,7 +1419,8 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
 
     // Add "from" source paragraph, if source is not THIS page
     let _addSource = (url)=>{
-        if(url == Nutshell.thisPageURL){
+        let urlSansHash = url.split("#")[0];
+        if(urlSansHash == Nutshell.thisPageURL){
             return ''; // nah.
         }else{
             let urlSansProtocol = url.split("://")[1];


### PR DESCRIPTION
It seemed like the intent was to not display the source (the "from nutshell_website.ca") if the source is from the same page. I like this feature because otherwise there would be links to hidden headings (headings that start with `:x`) that don't work properly. Unfortunately, the feature has a bug where links to headings are treated as different pages. This 2 line PR fixes this bug.