### PR TITLE
Fix latex in expandable links

### DIFF
--- a/nutshell.js
+++ b/nutshell.js
@@ -640,8 +640,9 @@ Bubble: the box that expands below an expandable, containing a Nutshell Section
 
             // Remove colon, replace with animated balls
             let linkText = document.createElement('span');
-            //linkText.innerHTML = ex.innerText.slice(ex.innerText.indexOf(':')+1); // CURSED LINE
-            linkText.innerText = ex.innerText.slice(ex.innerText.indexOf(':')+1);
+			// XSS vulnerability if without DOMPurify! (see https://github.com/ncase/nutshell/issues/32)
+			// Not using .innerText so that latex in links still works!
+            linkText.innerHTML = DOMPurify.sanitize(ex.innerText.slice(ex.innerText.indexOf(':')+1));
             linkText.className = 'nutshell-expandable-text';
             let ballUp = document.createElement('span');
             ballUp.className = 'nutshell-ball-up';


### PR DESCRIPTION
This PR makes latex expressions display properly when embedded in an expandable link. 

Previously, katex expressions wouldn't display properly because `innerText` was used instead of `innerHTML`. 

`DOMPurify.sanitize` is used to prevent an XSS vulnerability.